### PR TITLE
Update IJE0S (Standard Units).xdf

### DIFF
--- a/IJE0S (Standard Units).xdf
+++ b/IJE0S (Standard Units).xdf
@@ -5998,7 +5998,7 @@
       <units>Load Act.</units>
       <decimalpl>2</decimalpl>
       <min>0.000000</min>
-      <max>2.000000</max>
+      <max>300.000000</max>
       <outputtype>1</outputtype>
       <MATH equation="X/100">
         <VAR id="X" />


### PR DESCRIPTION
Those of us with N54T cars can use this function as a gear based load adder on top of the base load targets. My stock 335is bin has some values as high as 18 so a maximum of 2 is inappropriate. I suggested 300 simply to match your current maximum for the base load targets but it could easily be lower. I run less than 50 just as a way to limit boost in 1st and 2nd gear.
